### PR TITLE
Don’t force mixins to be declared first.

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -12,7 +12,7 @@ rules:
   placeholder-in-extend: 1
 
   # Mixins
-  mixins-before-declarations: 1
+  mixins-before-declarations: 0
 
   # Line Spacing
   one-declaration-per-line: 1


### PR DESCRIPTION
> When building mobile first I'd probably have all my device agnostic styles at the top and then mixins after.
 — @superfunkminister 